### PR TITLE
Auto-create initial issue from ai_prompt_input on new repo creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -493,7 +493,7 @@ func handleViewSubmission(ctx context.Context, logger *Logger, redisClient *redi
 
 		// Create the issue using gh issue create
 		// We use -R to specify the repository explicitly
-		ghIssueCreateCmd := fmt.Sprintf("gh issue create -R %s --title 'Initial Copilot Issue' --body '%s'", repoFullName, escapedPrompt)
+		ghIssueCreateCmd := fmt.Sprintf("gh issue create -R %s --title 'Initial Issue' --body '%s'", repoFullName, escapedPrompt)
 
 		poppitCmd.Commands = append(poppitCmd.Commands, sleepCmd, ghIssueCreateCmd)
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -156,6 +157,7 @@ type Config struct {
 	VibeOpsWorkingDir          string
 	GithubPrivateWorkingDir    string
 	LogLevel                   string
+	IssueCreationDelay         int
 }
 
 func loadConfig() (*Config, error) {
@@ -174,6 +176,15 @@ func loadConfig() (*Config, error) {
 		GithubPrivateWorkingDir:    getEnv("GITHUB_PRIVATE_WORKING_DIR", ""),
 		LogLevel:                   getEnv("LOG_LEVEL", "info"),
 	}
+
+	// Parse issue creation delay
+	delayStr := getEnv("ISSUE_CREATION_DELAY", "5")
+	delay, err := strconv.Atoi(delayStr)
+	if err != nil {
+		log.Printf("[WARN] Invalid ISSUE_CREATION_DELAY '%s', using default of 5 seconds", delayStr)
+		delay = 5
+	}
+	config.IssueCreationDelay = delay
 
 	if config.SlackToken == "" {
 		return nil, fmt.Errorf("SLACK_BOT_TOKEN must be set via environment variable")
@@ -469,6 +480,22 @@ func handleViewSubmission(ctx context.Context, logger *Logger, redisClient *redi
 			ghRepoCloneCmd,
 			ghVibeInitCmd,
 		},
+	}
+
+	// Check if AI prompt is provided and create an initial issue
+	aiPrompt := values["ai-prompt"]
+	if aiPrompt != "" {
+		// Escape single quotes for shell safety
+		escapedPrompt := strings.ReplaceAll(aiPrompt, `'`, `'\''`)
+
+		// Add delay to ensure repo is ready
+		sleepCmd := fmt.Sprintf("sleep %d", config.IssueCreationDelay)
+
+		// Create the issue using gh issue create
+		// We use -R to specify the repository explicitly
+		ghIssueCreateCmd := fmt.Sprintf("gh issue create -R %s --title 'Initial Copilot Issue' --body '%s'", repoFullName, escapedPrompt)
+
+		poppitCmd.Commands = append(poppitCmd.Commands, sleepCmd, ghIssueCreateCmd)
 	}
 
 	// Push to Poppit list

--- a/main_test.go
+++ b/main_test.go
@@ -335,6 +335,58 @@ func TestExtractViewValues(t *testing.T) {
 				"vibeops-config": "true",
 			},
 		},
+		{
+			name: "WithAIPrompt",
+			payload: ViewSubmissionPayload{
+				View: struct {
+					CallbackID string `json:"callback_id"`
+					State      struct {
+						Values map[string]map[string]struct {
+							Type            string `json:"type"`
+							Value           string `json:"value"`
+							SelectedOptions []struct {
+								Value string `json:"value"`
+							} `json:"selected_options"`
+						} `json:"values"`
+					} `json:"state"`
+				}{
+					State: struct {
+						Values map[string]map[string]struct {
+							Type            string `json:"type"`
+							Value           string `json:"value"`
+							SelectedOptions []struct {
+								Value string `json:"value"`
+							} `json:"selected_options"`
+						} `json:"values"`
+					}{
+						Values: map[string]map[string]struct {
+							Type            string `json:"type"`
+							Value           string `json:"value"`
+							SelectedOptions []struct {
+								Value string `json:"value"`
+							} `json:"selected_options"`
+						}{
+							"repo-name": {
+								"repo_name_input": {
+									Type:  "plain_text_input",
+									Value: "my-repo",
+								},
+							},
+							"ai-prompt": {
+								"ai_prompt_input": {
+									Type:  "plain_text_input",
+									Value: "Test AI Prompt",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"repo-name": "my-repo",
+				"ai-prompt": "Test AI Prompt",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,5 +445,47 @@ func TestLoadConfigWithoutGithubPrivateWorkingDir(t *testing.T) {
 
 	if config.GithubPrivateWorkingDir != "" {
 		t.Errorf("GithubPrivateWorkingDir = %q, want empty string", config.GithubPrivateWorkingDir)
+	}
+}
+
+// TestLoadConfigWithIssueCreationDelay tests that the ISSUE_CREATION_DELAY is correctly loaded
+func TestLoadConfigWithIssueCreationDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int
+	}{
+		{"ValidDelay", "10", 10},
+		{"DefaultDelay", "", 5},
+		{"InvalidDelay", "abc", 5},
+		{"ZeroDelay", "0", 0},
+		{"NegativeDelay", "-1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up test environment
+			os.Setenv("SLACK_BOT_TOKEN", "test-token")
+			os.Setenv("GITHUB_ORG", "test-org")
+			if tt.envValue != "" {
+				os.Setenv("ISSUE_CREATION_DELAY", tt.envValue)
+			} else {
+				os.Unsetenv("ISSUE_CREATION_DELAY")
+			}
+			defer func() {
+				os.Unsetenv("SLACK_BOT_TOKEN")
+				os.Unsetenv("GITHUB_ORG")
+				os.Unsetenv("ISSUE_CREATION_DELAY")
+			}()
+
+			config, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig() failed: %v", err)
+			}
+
+			if config.IssueCreationDelay != tt.expected {
+				t.Errorf("IssueCreationDelay = %d, want %d", config.IssueCreationDelay, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This change implements the automatic creation of an initial GitHub issue when a new repository is created through the Slack modal, provided the `ai_prompt_input` field is populated.

Key changes:
1. **Configuration**: Introduced `ISSUE_CREATION_DELAY` environment variable (mapped to `Config.IssueCreationDelay`) to allow a configurable wait time (defaulting to 5 seconds) after repo creation before attempting to create the issue.
2. **Issue Creation Logic**: In `handleViewSubmission`, if `ai-prompt` is present in the view state:
   - A `sleep` command is added to the Poppit command sequence.
   - A `gh issue create` command is appended, using a default title "Initial Copilot Issue" and the prompt content as the body.
3. **Safety**: Single quotes in the AI prompt and repository description are escaped to prevent shell injection.
4. **Testing**:
   - Added a test case to `TestExtractViewValues` to verify `ai-prompt` is correctly extracted from the Slack payload.
   - Added `TestLoadConfigWithIssueCreationDelay` to verify proper parsing of the new environment variable, including default and error cases.

Verified with `make test`.

Fixes #48

---
*PR created automatically by Jules for task [14955406871157633682](https://jules.google.com/task/14955406871157633682) started by @vibe-chung*